### PR TITLE
fix: Automatically update app version of Helm chart

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,7 +25,7 @@ jobs:
           docker push ghcr.io/$GITHUB_ACTOR/$imageName:${{ github.event.release.tag_name }}
 
       - name: Package Helm chart
-        run: helm package kubeview --version 0.0.0
+        run: helm package kubeview --version 0.0.0 --app-version ${{ github.event.release.tag_name }}
         working-directory: ./charts
 
       - name: Upload Helm chart to release


### PR DESCRIPTION
Relates to https://github.com/benc-uk/kubeview/issues/42

Happy to re-use the same version for the chart if you prefer that, but you might want to use different versions.