### PR TITLE
Create a cluster scoped role and binding to allow access to PV

### DIFF
--- a/charts/kubeview/templates/service-account.yaml
+++ b/charts/kubeview/templates/service-account.yaml
@@ -36,7 +36,6 @@ rules:
       - endpoints
       - namespaces
       - nodes
-      - persistentvolumes
       - persistentvolumeclaims
       - resourcequotas
       - services
@@ -64,6 +63,34 @@ roleRef:
   kind: ClusterRole
   {{ end }}
   name: {{ include "kubeview.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubeview.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubeview.fullname" . }}-pv
+rules:
+  - apiGroups: [""]
+    resources:
+      - persistentvolumes
+    verbs: ["get", "list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubeview.fullname" . }}-pv
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubeview.fullname" . }}-pv
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubeview.fullname" . }}


### PR DESCRIPTION
See issue #60 .  Not sure if this is the most desirable approach, but demonstrating a possible fix when deploying using helm ```limitNamespace: true``` and the generated ServiceAccount cannot be used by the scrape API to fetch PersistentVolume data as it is only using a RoleBinding..