### PR TITLE
Allow disabling both load balancer and ingress

### DIFF
--- a/charts/example-values.yaml
+++ b/charts/example-values.yaml
@@ -15,3 +15,8 @@ ingress:
   #  - secretName: my-cert
   #    hosts:
   #      - kubeview.example.net
+
+loadBalancer:
+  enabled: true
+
+  IP: '1.2.3.4'

--- a/charts/kubeview/templates/service.yaml
+++ b/charts/kubeview/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   {{ if .Values.ingress.enabled }}
   type: ClusterIP
-  {{ else }}
+  {{ else if .Values.loadBalancer.enabled }}
   type: LoadBalancer
   {{ end }}
   ports:
@@ -18,6 +18,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kubeview.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Values.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.loadBalancerIP }}
+{{- if (and .Values.loadBalancer.enabled .Values.loadBalancer.IP) }}
+  loadBalancerIP: {{ .Values.loadBalancer.IP }}
 {{- end }}

--- a/charts/kubeview/values.yaml
+++ b/charts/kubeview/values.yaml
@@ -26,7 +26,10 @@ ingress:
   tls: []
   className:
 
-loadBalancerIP: ''
+loadBalancer:
+  IP: ''
+
+  enabled: true
 
 resources:
   limits:


### PR DESCRIPTION
Preserves the default behaviour of creating a load balancer, but allows disabling it with `loadBalancer.enabled: false`. Also changes the load balancer IP parameter from `loadBalancerIP` to `loadBalancer.IP`.

Closes #71