### PR TITLE
Update to add security context sections

### DIFF
--- a/charts/example-values.yaml
+++ b/charts/example-values.yaml
@@ -22,3 +22,6 @@ loadBalancer:
   enabled: true
   # If you have an existing IP you can set it here
   # IP: "1.2.3.4"
+
+runasnonroot: true
+dropcapabilities: true

--- a/charts/kubeview/templates/deployment.yaml
+++ b/charts/kubeview/templates/deployment.yaml
@@ -46,9 +46,21 @@ spec:
               port: 8000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{ if .Values.dropcapabilities }}
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+              - CAP_NET_RAW
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ if .Values.runasnonroot }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       {{- end }}
     {{- with .Values.affinity }}
       affinity:

--- a/charts/kubeview/values.yaml
+++ b/charts/kubeview/values.yaml
@@ -48,3 +48,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+dropcapabilities: {}
+runasnonroot: {}


### PR DESCRIPTION
Kubeview has no need to run as root, or to have the netcap capabilities. Many organizations' security policies (such as where I work) disallow these unless strictly necessary to mitigate risk.