### PR TITLE
FEAT: Add DISABLE_POD_LOGS environment variable to control pod log access

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ The following environment variables are supported:
 - `PORT`: The port on which the KubeView server will listen. Default is `8000`.
 - `SINGLE_NAMESPACE`: If set, KubeView will only show resources in the specified namespace
 - `NAMESPACE_FILTER`: A regex pattern to filter namespaces. If set, namespaces that match the pattern will be _excluded_ e.g. `NAMESPACE_FILTER=^kube-` will not show system namespaces starting with `kube-`.
+- `DISABLE_POD_LOGS`: If set to `true` or `1`, pod logs will not be available via the API, or to view in the UI. This is useful for environments where you do not want to expose pod logs to users. Default is `false`.
 
 In addition the standard `KUBE_CONFIG` environment variable can be used to specify a custom path to the Kubernetes configuration file. If not set, it defaults to `$HOME/.kube/config`.
 

--- a/server/api.go
+++ b/server/api.go
@@ -23,10 +23,11 @@ type NamespaceListResult struct {
 	Namespaces []string `json:"namespaces"`
 	// We munge a couple of extra fields into the API response
 	// This saves us from having to make a separate request for the version and build info
-	ClusterHost string `json:"clusterHost"`
-	Version     string `json:"version"`
-	BuildInfo   string `json:"buildInfo"`
-	Mode        string `json:"mode"`
+	ClusterHost    string `json:"clusterHost"`
+	Version        string `json:"version"`
+	BuildInfo      string `json:"buildInfo"`
+	Mode           string `json:"mode"`
+	PodLogsEnabled bool   `json:"podLogsEnabled"`
 }
 
 func NewKubeviewAPI(conf Config) *KubeviewAPI {

--- a/server/config.go
+++ b/server/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	NameSpaceFilter string
 	SingleNamespace string
 	Debug           bool
+	EnablePodLogs   bool
 }
 
 // Parse the environment variables and return a Config struct
@@ -25,6 +26,7 @@ func getConfig() Config {
 	nameSpaceFilter := ""
 	singleNamespace := ""
 	debug := false
+	enablePodLogs := true
 
 	if portEnv := os.Getenv("PORT"); portEnv != "" {
 		if p, err := strconv.Atoi(portEnv); err == nil {
@@ -40,6 +42,12 @@ func getConfig() Config {
 		nameSpaceFilter = s
 	}
 
+	if s := os.Getenv("DISABLE_POD_LOGS"); s != "" {
+		if enable, err := strconv.ParseBool(s); err == nil {
+			enablePodLogs = !enable
+		}
+	}
+
 	if debugEnv := os.Getenv("DEBUG"); debugEnv != "" {
 		debug, _ = strconv.ParseBool(debugEnv)
 	}
@@ -49,5 +57,6 @@ func getConfig() Config {
 		NameSpaceFilter: nameSpaceFilter,
 		SingleNamespace: singleNamespace,
 		Debug:           debug,
+		EnablePodLogs:   enablePodLogs,
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -145,6 +145,11 @@ func (s *KubeviewAPI) handleFetchData(w http.ResponseWriter, r *http.Request) {
 
 // Pull logs for a specific pod in a namespace
 func (s *KubeviewAPI) GetPodLogs(w http.ResponseWriter, r *http.Request) {
+	if !s.config.EnablePodLogs {
+		s.ReturnText(w, "Viewing logs has been disabled by the administrator")
+		return
+	}
+
 	ns := chi.URLParam(r, "namespace")
 	podName := chi.URLParam(r, "podname")
 


### PR DESCRIPTION
New feature - option to disable the pod logs with a env var setting `DISABLE_POD_LOGS`

closes #127