### PR TITLE
FIX: Add permissions for Horizontal Pod Autoscalers in service account

### DIFF
--- a/deploy/helm/kubeview/templates/service-account.yaml
+++ b/deploy/helm/kubeview/templates/service-account.yaml
@@ -50,6 +50,11 @@ rules:
       - cronjobs
     verbs: ["get", "list", "watch"]
 
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+
   - apiGroups: ["discovery.k8s.io"]
     resources:
       - endpointslices


### PR DESCRIPTION
This pull request updates the Kubernetes service account configuration to include permissions for horizontal pod autoscalers.

Fix #134 

* [`deploy/helm/kubeview/templates/service-account.yaml`](diffhunk://#diff-35bb295646c339ae30ecb7a3f0b9b0c36ce5f324e66bf850cc923c9fe2653eb6R53-R57): Added rules to grant access to the `horizontalpodautoscalers` resource in the `autoscaling` API group with `get`, `list`, and `watch` verbs.