### PR TITLE
Find exact match

### DIFF
--- a/public/js/cache.js
+++ b/public/js/cache.js
@@ -58,11 +58,7 @@ export function queryRes(filterFn) {
  * @returns {Resource | null} The first resource that matches the kind and name, or null if not found
  */
 export function findResByName(kind, name) {
-  const list = Object.values(resMap).filter((res) => {
-    return res.kind === kind && res.metadata.name.toLowerCase().includes(name.toLowerCase())
-  })
-
-  return list[0]
+  return Object.values(resMap).find((res) => res.kind === kind && res.metadata.name === name)
 }
 
 /**


### PR DESCRIPTION
Fixes #140 

The `findResByName` function returned the first resource whose name contained the search string.

Now it instead returns the shortest-named resource whose name contains the search string. The assumption is that if there are multiple matches, one is a longer name, that coincidentally also contains the search string, but is not the intended resource. The shortest one is the actual intended match.

There may still be edge cases where this too fails. Especially when you get creative with kubernetes name generation.