### PR TITLE
Add option to hide empty replicasets

### DIFF
--- a/public/fragments/config-dialog.html
+++ b/public/fragments/config-dialog.html
@@ -66,6 +66,13 @@
               </select>
             </div>
           </div>
+          <div class="field mt-4">
+            <label class="checkbox">
+              <input type="checkbox" x-model="cfg.hideEmptyReplicaSets" :disabled="!cfg.resFilter.includes('ReplicaSet')" />
+              Hide ReplicaSets without replicas
+            </label>
+            <p class="help">Only applies when ReplicaSets are enabled in the filter</p>
+          </div>
         </div>
         <div :class="{'is-hidden':configTab!=3}">
           <div class="field">

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -13,6 +13,7 @@ const defaultConfig = {
   debug: false,
   shortenNames: true,
   spacing: 100,
+  hideEmptyReplicaSets: false,
   resFilter: [
     'Pod',
     'Deployment',
@@ -47,13 +48,20 @@ export function getConfig() {
 
   // Get the config from local storage
   const cfg = JSON.parse(localStorage.getItem('kubeviewConfig') || 'null')
-  config = cfg
+  config = {
+    ...defaultConfig,
+    ...cfg,
+  }
   return config || defaultConfig
 }
 
+/**
+ * Save the configuration object to local storage
+ * @param {Config} newConfig
+ */
 export async function saveConfig(newConfig) {
   // Weird bug where spacing is a string instead of a number
-  newConfig.spacing = parseInt(newConfig.spacing) || 100
+  newConfig.spacing = parseInt(`${newConfig.spacing}`) || 100
 
   // Set the config in local storage
   localStorage.setItem('kubeviewConfig', JSON.stringify(newConfig))

--- a/public/js/types/custom.d.ts
+++ b/public/js/types/custom.d.ts
@@ -16,6 +16,7 @@ declare type Config = {
   shortenNames: boolean
   resFilter: string[]
   spacing: number
+  hideEmptyReplicaSets: boolean
 }
 
 // Represents a generic Kubernetes resource


### PR DESCRIPTION
First off, apologies for not first creating an issue to discuss this feature. Feel free to discard it if undesired.

## Background

Our Kubernetes keeps revision history of replica sets. However the graph layout mechanism used in kubeview has some issues with it:

- The tree layout gets completely tangled when even two revisions are kept. For some reason it can't properly layout the isolated subtrees and they end up all tangled.
- The natural layout is unnecessarily busy

Furthermore in our use case, we don't need to see those revisions at all. Their function is more akin to config maps.

## User Story

As a Kubeview user observing the status of my cluster
I'd like to hide the "revision history" replica sets.
So that I can see only replicasets relevant to the current status

## Approach

Keeping a replica sets for revision history is done by setting their replica count to zero.
Therefore I decided to add an option to hide replica sets which have zero replicas.

The option is a checkbox in the filters tab of the configuration dialogue, below the current configuration list. The checkbox is disabled if `ReplicaSet` is not currently selected in the filter.

## Pictures

Before:
<img width="1898" height="106" alt="before" src="https://github.com/user-attachments/assets/4b2fbbbb-0821-4253-944b-d503e97e927e" />

After:
<img width="1878" height="138" alt="after" src="https://github.com/user-attachments/assets/702238e5-7975-4f33-b314-a3cd70445e27" />

Option not enabled:
<img width="647" height="725" alt="inactive" src="https://github.com/user-attachments/assets/12e96907-802e-4a38-8950-9965872432dc" />

Checkbox disabled:
<img width="645" height="720" alt="disabled" src="https://github.com/user-attachments/assets/a0b190e7-cbf7-4634-812f-34482bf8efa2" />

Option enabled:
<img width="643" height="723" alt="active" src="https://github.com/user-attachments/assets/1c0783c3-0af9-4f7c-acca-8d02a5356f89" />


