### PR TITLE
Container specific log reading

### DIFF
--- a/frontend/fragments/logs-dialog.html
+++ b/frontend/fragments/logs-dialog.html
@@ -1,16 +1,16 @@
 <!-- This is the dialog for showing pod logs, note it uses the sidePanel component for data -->
-<div class="modal is-active" x-data="sidePanel" x-show="showLogsDialog" x-cloak>
-  <div class="modal-background" @click="showLogsDialog = false"></div>
-  <div class="modal-card" style="width:80vw">
+<div class="modal is-active" x-data="sidePanel" x-show="!!showLogsForContainer" x-cloak>
+  <div class="modal-background" @click="showLogsForContainer = null"></div>
+  <div class="modal-card" style="width: 80vw">
     <header class="modal-card-head has-background-primary py-3">
       <p class="modal-card-title has-text-black" x-text="`Pod Logs: ${panelData.props.name}`"></p>
-      <button @click="showLogs(panelData.props.name)" class="button is-small is-dark mr-3">
+      <button @click="showLogs(panelData.props.name, showLogsForContainer)" class="button is-small is-dark mr-3">
         <span class="icon"><i class="fas fa-rotate"></i></span>
         <span>Update Logs</span>
       </button>
-      <button class="delete" aria-label="close" @click="showLogsDialog = false"></button>
+      <button class="delete" aria-label="close" @click="showLogsForContainer = null"></button>
     </header>
-    <div class="modal-content" style="width:100%">
+    <div class="modal-content" style="width: 100%">
       <textarea x-text="logs" readonly id="logArea"></textarea>
     </div>
   </div>

--- a/frontend/fragments/side-panel.html
+++ b/frontend/fragments/side-panel.html
@@ -1,19 +1,16 @@
 <!-- This shows a side panel filled with info about a resource when clicked -->
-<article class="panel is-link" x-data="sidePanel" id="infoPanel" x-transition:enter="slidein"
-  x-transition:leave="slideout" x-show="open" x-cloak>
+<article class="panel is-link" x-data="sidePanel" id="infoPanel" x-transition:enter="slidein" x-transition:leave="slideout" x-show="open" x-cloak>
   <p class="panel-heading py-2">
     <img :src="`public/img/res/${panelData.icon}.svg`" width="32" height="32" class="valign-middle" />
     <span x-text="panelData.kind" class="valign-middle"></span>
   </p>
   <section>
     <div class="panel-block is-flex">
-      <button class="button is-small is-light mr-1" :class="{'is-outlined':!showLabels}"
-        @click="showLabels=!showLabels; showAnno=false">Labels</button>
-      <button class="button is-small is-light mr-3" :class="{'is-outlined':!showAnno}"
-        @click="showAnno=!showAnno; showLabels=false">Annotations</button>
-      <button class="button is-small is-primary" @click="showLogs(panelData.props.name)" x-show="isPod">
-        <span class="icon"><i class="fas fa-rectangle-list"></i></span>
-        <span>Pod Logs</span>
+      <button class="button is-small is-light mr-1" :class="{'is-outlined':!showLabels}" @click="showLabels=!showLabels; showAnno=false">
+        Labels
+      </button>
+      <button class="button is-small is-light mr-3" :class="{'is-outlined':!showAnno}" @click="showAnno=!showAnno; showLabels=false">
+        Annotations
       </button>
     </div>
     <!-- Labels & Annotations -->
@@ -32,7 +29,8 @@
     <!-- Properties -->
     <div
       class="panel-block has-background-dark py-0 is-flex is-justify-content-space-around is-align-items-center clickable"
-      @click="showProps=!showProps">
+      @click="showProps=!showProps"
+    >
       <label class="label is-flex-grow-1 pt-1 mr-3 clickable">Properties</label>
       <i class="fas" :class="showProps ? 'fa-angles-up' : 'fa-angles-down'"></i>
     </div>
@@ -46,9 +44,15 @@
     <template x-for="(cont, name) in panelData.containers" :key="name">
       <div>
         <div
-          class="panel-block has-background-dark py-0 is-flex is-justify-content-space-around is-align-items-center clickable"
-          @click="showContainers=!showContainers" style="cursor: pointer">
-          <label class="label is-flex-grow-1 pt-1 mr-3 clickable" x-text="`Container: ${name}`"></label>
+          class="panel-block has-background-dark py-0 is-flex is-justify-content-flex-start is-align-items-center clickable"
+          @click="showContainers=!showContainers"
+          style="cursor: pointer"
+        >
+          <label class="label pt-1 mr-2 clickable is-flex-grow-1" x-text="`Container: ${name}`"></label>
+          <button class="button is-small is-primary mr-2" @click.stop="showLogs(panelData.props.name, name)" x-show="isPod">
+            <span class="icon"><i class="fas fa-rectangle-list"></i></span>
+            <span>Container Logs</span>
+          </button>
           <i class="fas" :class="showContainers ? 'fa-angles-up' : 'fa-angles-down'"></i>
         </div>
         <template x-for="(value, prop) in cont" :key="prop">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -108,7 +108,7 @@ Alpine.data('mainApp', () => ({
   cfg: getConfig(),
   searchQuery: '',
   showEventsDialog: false,
-  showLogsDialog: false,
+  showLogsForContainer: null,
   logs: '',
   connState: 'connecting', // 'connecting', 'connected', 'disconnected'
   togglePaused,

--- a/frontend/js/side-panel.js
+++ b/frontend/js/side-panel.js
@@ -231,19 +231,19 @@ export default () => ({
     }
   },
 
-  async showLogs(podName) {
-    console.log(`📜 Fetching logs for pod ${podName} in namespace ${this.namespace}`)
+  async showLogs(podName, containerName) {
+    console.log(`📜 Fetching logs for pod ${podName} container ${containerName} in namespace ${this.namespace}`)
     this.isLoading = true
 
     // Note these properties are in the parent mainApp component
     // It didn't work having them here, so we use the parent component's properties
-    this.showLogsDialog = true
+    this.showLogsForContainer = containerName
     this.logs = ''
 
     // Fetch logs from the server, the last 300 lines
     let res
     try {
-      res = await fetch(`api/logs/${this.namespace}/${podName}?max=300`)
+      res = await fetch(`api/logs/${this.namespace}/${podName}/${containerName}?max=300`)
       if (!res.ok) throw new Error(`HTTP error ${res.status}: ${res.statusText}`)
 
       this.isLoading = false

--- a/server/routes.go
+++ b/server/routes.go
@@ -49,7 +49,7 @@ func (s *KubeviewAPI) AddRoutes(r *chi.Mux) {
 	// REST API routes
 	r.Get("/api/namespaces", s.handleNamespaceList)
 	r.Get("/api/fetch/{namespace}", s.handleFetchData)
-	r.Get("/api/logs/{namespace}/{podname}", s.handlePodLogs)
+	r.Get("/api/logs/{namespace}/{podname}/{containername}", s.handlePodLogs)
 }
 
 // Establish the SSE connection for streaming updates each client
@@ -168,6 +168,7 @@ func (s *KubeviewAPI) handlePodLogs(w http.ResponseWriter, r *http.Request) {
 
 	ns := chi.URLParam(r, "namespace")
 	podName := chi.URLParam(r, "podname")
+	containerName := chi.URLParam(r, "containername")
 
 	count := r.URL.Query().Get("max")
 	if count == "" {
@@ -180,7 +181,7 @@ func (s *KubeviewAPI) handlePodLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logs, err := s.kubeService.GetPodLogs(ns, podName, logCount)
+	logs, err := s.kubeService.GetPodLogs(ns, podName, containerName, logCount)
 	if err != nil {
 		// Note: We don't send a problem response here, as we want to return something even if there's an error
 		// This is more graceful as the pod might not be in a state to fetch logs

--- a/server/services/kubernetes.go
+++ b/server/services/kubernetes.go
@@ -336,7 +336,7 @@ func (k *Kubernetes) GetResources(ns string, grp string, ver string, res string)
 }
 
 // Retrieves the logs of a specific pod in a given namespace
-func (k *Kubernetes) GetPodLogs(ns, podName string, lineCount int) (string, error) {
+func (k *Kubernetes) GetPodLogs(ns, podName string, containerName string, lineCount int) (string, error) {
 	if ns == "" || podName == "" {
 		return "", errors.New("namespace or pod name is empty")
 	}
@@ -347,6 +347,7 @@ func (k *Kubernetes) GetPodLogs(ns, podName string, lineCount int) (string, erro
 
 	// Get the lines of logs from the pod
 	req := k.clientSet.CoreV1().Pods(ns).GetLogs(podName, &coreV1.PodLogOptions{
+		Container: containerName,
 		TailLines: &[]int64{int64(lineCount)}[0], // We pass in how many lines we want to get
 	})
 

--- a/server/services/kubernetes.go
+++ b/server/services/kubernetes.go
@@ -337,8 +337,12 @@ func (k *Kubernetes) GetResources(ns string, grp string, ver string, res string)
 
 // Retrieves the logs of a specific pod in a given namespace
 func (k *Kubernetes) GetPodLogs(ns, podName string, containerName string, lineCount int) (string, error) {
-	if ns == "" || podName == "" {
-		return "", errors.New("namespace or pod name is empty")
+	if ns == "" {
+		return "", errors.New("namespace is empty")
+	} else if podName == "" {
+		return "", errors.New("pod name is empty")
+	} else if containerName == "" {
+		return "", errors.New("container name is empty")
 	}
 
 	if lineCount <= 0 {

--- a/server/services/kubernetes_test.go
+++ b/server/services/kubernetes_test.go
@@ -265,19 +265,19 @@ func TestKubernetes_GetPodLogs(t *testing.T) {
 	k := mockKubernetes()
 
 	// Test empty namespace
-	_, err := k.GetPodLogs("", "test-pod", 100)
+	_, err := k.GetPodLogs("", "test-pod", "test-container", 100)
 	if err == nil {
 		t.Error("Expected error for empty namespace, got nil")
 	}
 
 	// Test empty pod name
-	_, err = k.GetPodLogs("default", "", 100)
+	_, err = k.GetPodLogs("default", "", "test-container", 100)
 	if err == nil {
 		t.Error("Expected error for empty pod name, got nil")
 	}
 
 	// Test default line count
-	_, err = k.GetPodLogs("default", "test-pod", 0)
+	_, err = k.GetPodLogs("default", "test-pod", "test-container", 0)
 	// This will fail because we're using a fake client, but we can check that the validation works
 	if err != nil {
 		// This is expected to fail with the fake client


### PR DESCRIPTION
First of all, once again apologies that I haven't discussed this, but there _is_ an issue #150 this time. So I'm improving.

## Background

Previously, Kubeview’s pod log viewer did not support selecting logs for individual containers within a pod. This caused issues for users with multi-container pods, as described in [#150](https://github.com/benc-uk/kubeview/issues/150):  
> “I do wonder what I should expect when I click pod logs on a pod with multiple containers. Does it just aggregate the logs for all containers? What if I want to see logs for an individual container in that pod? It seems like that should be possible, but I don't see a way to do that.”

## User Story

As a Kubeview user working with pods that have multiple containers,  
I want to be able to view logs for a specific container within a pod,  
So that I can monitor each container independently without errors.

## Approach

- Replaced the old “Pod Logs” button in the UI with a “Container Logs” button for each container in the side panel.
- The logs dialog now opens for a specific container, not just the pod as a whole.
- The backend API and log fetching logic were updated to now only support container-specific log retrieval.

## Screenshots

Before:
<img width="442" height="598" alt="before" src="https://github.com/user-attachments/assets/bae2dbec-3e03-4065-a6cc-94dccdc066b9" />

After:
<img width="450" height="597" alt="after" src="https://github.com/user-attachments/assets/4bcce28a-7839-4c05-b005-11e00904a152" />

## Potential rework

I'm not sure about the UI. It's functional, but it's a breaking change. I'm no UI/UX expert, so feel free to suggest another approach.

---

Closes #150.