### PR TITLE
feat: Add GitHub Actions workflow for binary builds

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,42 @@
+name: Test Binary Builds
+
+on:
+  workflow_dispatch:
+
+jobs:
+  binary-build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+          - os: windows
+            arch: amd64
+          - os: windows
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set BUILD_INFO based on git log
+        run: |
+          echo BUILD_INFO="test-build $(git log -1 --pretty=format:'%h %ad' --date=short)" >> ${GITHUB_ENV}
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+        run: make build
+
+      - name: List output
+        run: |
+          echo "=== Build output for ${{ matrix.os }}/${{ matrix.arch }} ==="
+          ls -lah bin/${{ matrix.os }}/
+          file bin/${{ matrix.os }}/kubeview || true


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`.github/workflows/test-build.yml`) for testing cross-platform binary builds.

## Changes

- New **manually triggered** workflow (`workflow_dispatch`) that builds binaries across a matrix of OS and architecture combinations:
  - linux/amd64, linux/arm64
  - darwin/amd64, darwin/arm64
  - windows/amd64, windows/arm64
- Sets `BUILD_INFO` from the git log for build metadata
- Runs `make build` with the appropriate `GOOS`/`GOARCH` environment variables
- Lists and verifies the build output for each target