### PR TITLE
fix: Dockerfile missing frontend embed files and incorrect public/ copy

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,6 +18,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY server/ ./server/
+COPY frontend/ ./frontend/
+COPY frontend-fs.go ./
 
 # CGO_ENABLED=0 is used to ensure a statically linked binary
 # TARGETOS and TARGETARCH are set to build for the desired platform
@@ -37,10 +39,8 @@ FROM --platform=$BUILDPLATFORM alpine:3.23
 
 WORKDIR /app
 
-# Copy binary and public assets
+# Copy binary (frontend is embedded via go:embed)
 COPY --from=build /build/kubeview .
-# Copy public web assets
-COPY public/ ./public/
 
 ENV PORT=8000
 EXPOSE 8000


### PR DESCRIPTION
## Pull Request Summary

Fixes the Dockerfile so the container image can be built successfully. The build stage was missing the `frontend/` directory and `frontend-fs.go` file required by Go's `//go:embed` directive, and the final stage incorrectly tried to copy a non-existent `public/` directory.

### Infrastructure & Build Changes

- **Added `COPY frontend/ ./frontend/` and `COPY frontend-fs.go ./` to the build stage** — The Go binary embeds the frontend assets at compile time via `//go:embed all:frontend` in `frontend-fs.go`. Both the embed directive file and the `frontend/` directory must be present during `go build`, but they were missing from the Dockerfile's build context.
- **Removed `COPY public/ ./public/` from the final stage** — The runtime image was trying to copy a `public/` directory that doesn't exist in the repository. Since frontend assets are embedded into the binary, no separate file copy is needed at runtime.

### Bug Fixes

- Fixed Docker image build failure caused by missing `frontend-fs.go` and `frontend/` directory in the build stage, which are required for the `//go:embed` directive to compile.
- Fixed Docker image build failure caused by `COPY public/ ./public/` referencing a directory that does not exist in the repository.