### PR TITLE
feat: k8sview sidecar patches (cache-read fetch, list-only mode, RBAC…

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -21,6 +21,10 @@ type KubeviewAPI struct {
 
 type NamespaceListResult struct {
 	Namespaces []string `json:"namespaces"`
+	// CanListNamespaces is false when the identity lacks cluster-scope
+	// namespaces.list permission (RBAC-restricted clusters). In that case
+	// Namespaces is empty and the client must let the user type a namespace.
+	CanListNamespaces bool `json:"canListNamespaces"`
 	// We munge a couple of extra fields into the API response
 	// This saves us from having to make a separate request for the version and build info
 	ClusterHost    string `json:"clusterHost"`
@@ -34,7 +38,7 @@ func NewKubeviewAPI(conf Config) *KubeviewAPI {
 	broker := newKubeEventBroker(conf)
 
 	// Create a new Kubernetes service instance, which will connect to the cluster
-	kubeSvc, err := services.NewKubernetes(broker.Broker, conf.SingleNamespace)
+	kubeSvc, err := services.NewKubernetes(broker.Broker, conf.SingleNamespace, conf.ListNamespacesOnly)
 	if err != nil {
 		log.Fatalf("💥 Error connecting to Kubernetes, system will exit")
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -11,11 +11,12 @@ import (
 
 // Config holds the configuration for the system
 type Config struct {
-	Port            int
-	NameSpaceFilter string
-	SingleNamespace string
-	Debug           bool
-	EnablePodLogs   bool
+	Port               int
+	NameSpaceFilter    string
+	SingleNamespace    string
+	ListNamespacesOnly bool
+	Debug              bool
+	EnablePodLogs      bool
 }
 
 // Parse the environment variables and return a Config struct
@@ -25,6 +26,7 @@ func getConfig() Config {
 	port := 8000
 	nameSpaceFilter := ""
 	singleNamespace := ""
+	listNamespacesOnly := false
 	debug := false
 	enablePodLogs := true
 
@@ -42,6 +44,14 @@ func getConfig() Config {
 		nameSpaceFilter = s
 	}
 
+	// List-only bootstrap mode: serve the namespace list without setting up any
+	// informers (no cluster-wide list/watch), so the HTTP server binds even on
+	// RBAC-restricted clusters. The client uses this to populate the namespace
+	// picker, then restarts the sidecar scoped via SINGLE_NAMESPACE.
+	if s := os.Getenv("LIST_NAMESPACES_ONLY"); s != "" {
+		listNamespacesOnly = true
+	}
+
 	if s := os.Getenv("DISABLE_POD_LOGS"); s != "" {
 		if enable, err := strconv.ParseBool(s); err == nil {
 			enablePodLogs = !enable
@@ -53,10 +63,11 @@ func getConfig() Config {
 	}
 
 	return Config{
-		Port:            port,
-		NameSpaceFilter: nameSpaceFilter,
-		SingleNamespace: singleNamespace,
-		Debug:           debug,
-		EnablePodLogs:   enablePodLogs,
+		Port:               port,
+		NameSpaceFilter:    nameSpaceFilter,
+		SingleNamespace:    singleNamespace,
+		ListNamespacesOnly: listNamespacesOnly,
+		Debug:              debug,
+		EnablePodLogs:      enablePodLogs,
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/benc-uk/go-rest-api/pkg/problem"
 	kubeview "github.com/benc-uk/kubeview"
 	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // All application routes are defined here
@@ -77,42 +78,53 @@ func (s *KubeviewAPI) handleNamespaceList(w http.ResponseWriter, r *http.Request
 
 	var err error
 
-	if s.config.SingleNamespace != "" {
-		// If SingleNamespace is set, we only return that namespace
-		namespaces = []string{s.config.SingleNamespace}
-	} else {
-		namespaces, err = s.kubeService.GetNamespaces()
-		if err != nil {
+	// Always return the full namespace list (a direct API List). We intentionally
+	// do NOT collapse to SingleNamespace here: k8sview watches one namespace
+	// (scoped informers) but still needs the full list to drive the namespace
+	// picker. The /api/fetch handler keeps its single-namespace enforcement.
+	canListNamespaces := true
+
+	namespaces, err = s.kubeService.GetNamespaces()
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			// RBAC-restricted identity: cannot enumerate namespaces. Come up
+			// anyway with an empty list and a flag, so the client stays usable
+			// and lets the user type the namespace they DO have access to.
+			log.Println("🔒 Not authorised to list namespaces; client must specify one")
+			namespaces = []string{}
+			canListNamespaces = false
+		} else {
 			problem.Wrap(500, r.RequestURI, "namespaces", err).Send(w)
 			return
 		}
+	}
 
-		// Remove namespaces that are in the filter, filter is a regex
-		if s.config.NameSpaceFilter != "" {
-			filteredNamespaces := make([]string, 0, len(namespaces))
+	// Remove namespaces that are in the filter, filter is a regex
+	if canListNamespaces && s.config.NameSpaceFilter != "" {
+		filteredNamespaces := make([]string, 0, len(namespaces))
 
-			for _, ns := range namespaces {
-				if matched, err := regexp.MatchString(s.config.NameSpaceFilter, ns); !matched && err == nil {
-					filteredNamespaces = append(filteredNamespaces, ns)
-				}
+		for _, ns := range namespaces {
+			if matched, err := regexp.MatchString(s.config.NameSpaceFilter, ns); !matched && err == nil {
+				filteredNamespaces = append(filteredNamespaces, ns)
 			}
-
-			if len(filteredNamespaces) == 0 {
-				problem.Wrap(500, r.RequestURI, "no namespaces found",
-					errors.New("no namespaces match the filter")).Send(w)
-				return
-			}
-
-			namespaces = filteredNamespaces
 		}
+
+		if len(filteredNamespaces) == 0 {
+			problem.Wrap(500, r.RequestURI, "no namespaces found",
+				errors.New("no namespaces match the filter")).Send(w)
+			return
+		}
+
+		namespaces = filteredNamespaces
 	}
 
 	res := NamespaceListResult{
-		ClusterHost: s.kubeService.ClusterHost,
-		Namespaces:  namespaces,
-		Version:     s.Version,
-		BuildInfo:   s.BuildInfo,
-		Mode:        s.kubeService.Mode,
+		ClusterHost:       s.kubeService.ClusterHost,
+		Namespaces:        namespaces,
+		CanListNamespaces: canListNamespaces,
+		Version:           s.Version,
+		BuildInfo:         s.BuildInfo,
+		Mode:              s.kubeService.Mode,
 	}
 
 	s.ReturnJSON(w, res)

--- a/server/services/kubernetes.go
+++ b/server/services/kubernetes.go
@@ -30,6 +30,7 @@ import (
 type Kubernetes struct {
 	dynamicClient     dynamic.Interface
 	clientSet         kubernetes.Interface
+	factory           dynamicinformer.DynamicSharedInformerFactory
 	ClusterHost       string
 	Mode              string // "in-cluster" or "out-of-cluster"
 	KubeVersion       string
@@ -60,7 +61,7 @@ const (
 
 // NewKubernetes creates a new Kubernetes service instance
 // - needs an SSE broker to send events to connected clients
-func NewKubernetes(sseBroker *sse.Broker[KubeEvent], singleNamespace string) (*Kubernetes, error) {
+func NewKubernetes(sseBroker *sse.Broker[KubeEvent], singleNamespace string, listOnly bool) (*Kubernetes, error) {
 	var kubeConfig *rest.Config
 
 	var err error
@@ -164,6 +165,10 @@ func NewKubernetes(sseBroker *sse.Broker[KubeEvent], singleNamespace string) (*K
 		Informer().
 		AddEventHandler(getHandlerFuncs(sseBroker))
 
+	_, _ = factory.ForResource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}).
+		Informer().
+		AddEventHandler(getHandlerFuncs(sseBroker))
+
 	_, _ = factory.ForResource(schema.GroupVersionResource{Group: "networking.k8s.io",
 		Version: "v1", Resource: "ingresses"}).
 		Informer().
@@ -210,12 +215,22 @@ func NewKubernetes(sseBroker *sse.Broker[KubeEvent], singleNamespace string) (*K
 		Informer().
 		AddEventHandler(getHandlerFuncs(sseBroker))
 
-	factory.Start(context.Background().Done())
-	factory.WaitForCacheSync(context.Background().Done())
+	// List-only mode: skip starting the informers and the blocking cache sync.
+	// The handlers/informers above are created but inert (no list/watch network
+	// calls happen until factory.Start), so the HTTP server binds immediately
+	// even on RBAC-restricted clusters. /api/fetch and /updates read empty
+	// caches in this mode and are not used by the client here.
+	if !listOnly {
+		factory.Start(context.Background().Done())
+		factory.WaitForCacheSync(context.Background().Done())
+	} else {
+		log.Println("📋 List-only mode: skipping resource watchers")
+	}
 
 	return &Kubernetes{
 		dynamicClient:     dynamicClient,
 		clientSet:         clientSet, // Deprecated, use client instead
+		factory:           factory,
 		ClusterHost:       kubeConfig.Host,
 		Mode:              mode,
 		UseEndpointSlices: useEndpointSlices,
@@ -254,52 +269,47 @@ func (k *Kubernetes) CheckNamespaceExists(ns string) bool {
 	return err == nil
 }
 
-// Retrieves all resources in a specific namespace and returns them in a big ol' map
+// Retrieves all resources in a specific namespace and returns them in a big ol' map.
+// Reads from the in-memory informer cache populated by NewKubernetes, avoiding
+// per-request List calls against the API server.
 func (k *Kubernetes) FetchNamespace(ns string) (map[string][]unstructured.Unstructured, error) {
 	if ns == "" {
 		return nil, errors.New("namespace is empty")
 	}
 
-	data := make(map[string][]unstructured.Unstructured)
+	type kindGVR struct {
+		key string
+		gvr schema.GroupVersionResource
+	}
 
-	podList, _ := k.GetResources(ns, "", "v1", "pods")
-	serviceList, _ := k.GetResources(ns, "", "v1", "services")
-	// endpointList, _ := k.getResources(ns, "", "v1", "endpoints")
-	deploymentList, _ := k.GetResources(ns, "apps", "v1", "deployments")
-	replicaSetList, _ := k.GetResources(ns, "apps", "v1", "replicasets")
-	statefulSetList, _ := k.GetResources(ns, "apps", "v1", "statefulsets")
-	daemonSetList, _ := k.GetResources(ns, "apps", "v1", "daemonsets")
-	jobList, _ := k.GetResources(ns, "batch", "v1", "jobs")
-	cronJobList, _ := k.GetResources(ns, "batch", "v1", "cronjobs")
-	ingressList, _ := k.GetResources(ns, "networking.k8s.io", "v1", "ingresses")
-	confMapList, _ := k.GetResources(ns, "", "v1", "configmaps")
-	secretList, _ := k.GetResources(ns, "", "v1", "secrets")
-	pvcList, _ := k.GetResources(ns, "", "v1", "persistentvolumeclaims")
-	eventList, _ := k.GetResources(ns, "", "v1", "events")
-	hpaList, _ := k.GetResources(ns, "autoscaling", "v2", "horizontalpodautoscalers")
+	kinds := []kindGVR{
+		{"pods", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}},
+		{"services", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}},
+		{"deployments", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}},
+		{"replicasets", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}},
+		{"statefulsets", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}},
+		{"daemonsets", schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}},
+		{"jobs", schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}},
+		{"cronjobs", schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"}},
+		{"ingresses", schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}},
+		{"configmaps", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}},
+		{"secrets", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}},
+		{"persistentvolumeclaims", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}},
+		{"events", schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}},
+		{"horizontalpodautoscalers", schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}},
+	}
 
-	data["pods"] = podList
-	data["services"] = serviceList
-	data["deployments"] = deploymentList
-	data["replicasets"] = replicaSetList
-	data["statefulsets"] = statefulSetList
-	data["daemonsets"] = daemonSetList
-	data["jobs"] = jobList
-	data["cronjobs"] = cronJobList
-	data["ingresses"] = ingressList
-	data["configmaps"] = confMapList
-	data["secrets"] = secretList
-	data["persistentvolumeclaims"] = pvcList
-	data["events"] = eventList
-	data["horizontalpodautoscalers"] = hpaList
+	data := make(map[string][]unstructured.Unstructured, len(kinds)+1)
+	for _, kg := range kinds {
+		data[kg.key] = k.listFromCache(kg.gvr, ns)
+	}
 
-	// If we are using EndpointSlices, get those instead of Endpoints
 	if k.UseEndpointSlices {
-		endpointList, _ := k.GetResources(ns, "discovery.k8s.io", "v1", "endpointslices")
-		data["endpointslices"] = endpointList
+		data["endpointslices"] = k.listFromCache(
+			schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}, ns)
 	} else {
-		endpointList, _ := k.GetResources(ns, "", "v1", "endpoints")
-		data["endpoints"] = endpointList
+		data["endpoints"] = k.listFromCache(
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}, ns)
 	}
 
 	// Clean up the managed fields and redact sensitive data
@@ -320,6 +330,34 @@ func (k *Kubernetes) FetchNamespace(ns string) (map[string][]unstructured.Unstru
 	}
 
 	return data, nil
+}
+
+// listFromCache returns deep-copied resources of the given GVR scoped to the
+// namespace, read from the shared informer's local cache. Returns an empty
+// slice (never nil) if the informer is unregistered or the cache is empty,
+// preserving the JSON shape returned by FetchNamespace.
+func (k *Kubernetes) listFromCache(gvr schema.GroupVersionResource, ns string) []unstructured.Unstructured {
+	out := []unstructured.Unstructured{}
+
+	if k.factory == nil {
+		return out
+	}
+
+	informer := k.factory.ForResource(gvr).Informer()
+	for _, obj := range informer.GetIndexer().List() {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+
+		if u.GetNamespace() != ns {
+			continue
+		}
+
+		out = append(out, *u.DeepCopy())
+	}
+
+	return out
 }
 
 // Generic function to list resources from a specific namespace
@@ -369,16 +407,30 @@ func inCluster() bool {
 	return false
 }
 
-// getHandlerFuncs returns the event handlers for the Kubernetes informers, which send events through the SSE broker
+// getHandlerFuncs returns the event handlers for the Kubernetes informers, which send events through the SSE broker.
+//
+// Each handler DeepCopies the incoming object before mutating it. The informer
+// hands out a pointer to the object held in the shared cache, and the listener
+// callbacks run on a goroutine pool concurrent with the informer's own delta
+// processing. Mutating the cached pointer races against `MetaNamespaceIndexFunc`
+// reads that happen inside the informer's `threadSafeMap` updates (Go's
+// runtime catches this as `fatal error: concurrent map read and map write`).
+// The DeepCopy makes the SSE pipeline operate on a private clone, leaving the
+// cache pristine for the Pack-2 cache-read path used by FetchNamespace.
 func getHandlerFuncs(b *sse.Broker[KubeEvent]) cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			u := obj.(*unstructured.Unstructured)
-			namespace := u.GetNamespace()
+			orig, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+
+			namespace := orig.GetNamespace()
 			if namespace == "" {
 				return
 			}
 
+			u := orig.DeepCopy()
 			u.SetManagedFields(nil)
 			b.SendToGroup(namespace, KubeEvent{
 				EventType: AddEvent,
@@ -387,12 +439,17 @@ func getHandlerFuncs(b *sse.Broker[KubeEvent]) cache.ResourceEventHandlerFuncs {
 		},
 
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			u := newObj.(*unstructured.Unstructured)
-			namespace := u.GetNamespace()
+			orig, ok := newObj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+
+			namespace := orig.GetNamespace()
 			if namespace == "" {
 				return
 			}
 
+			u := orig.DeepCopy()
 			u.SetManagedFields(nil)
 			b.SendToGroup(namespace, KubeEvent{
 				EventType: UpdateEvent,
@@ -401,12 +458,17 @@ func getHandlerFuncs(b *sse.Broker[KubeEvent]) cache.ResourceEventHandlerFuncs {
 		},
 
 		DeleteFunc: func(obj interface{}) {
-			u := obj.(*unstructured.Unstructured)
-			namespace := u.GetNamespace()
+			orig, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return
+			}
+
+			namespace := orig.GetNamespace()
 			if namespace == "" {
 				return
 			}
 
+			u := orig.DeepCopy()
 			u.SetManagedFields(nil)
 			b.SendToGroup(namespace, KubeEvent{
 				EventType: DeleteEvent,

--- a/server/services/kubernetes_integration_test.go
+++ b/server/services/kubernetes_integration_test.go
@@ -24,7 +24,7 @@ func TestNewKubernetes_Integration(t *testing.T) {
 	broker := sse.NewBroker[KubeEvent]()
 
 	// Test creating a new Kubernetes service
-	k, err := NewKubernetes(broker, "")
+	k, err := NewKubernetes(broker, "", false)
 	if err != nil {
 		t.Skipf("Skipping integration test - could not connect to Kubernetes: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestNewKubernetes_SingleNamespace_Integration(t *testing.T) {
 	broker := sse.NewBroker[KubeEvent]()
 
 	// Test creating a new Kubernetes service with single namespace
-	k, err := NewKubernetes(broker, "default")
+	k, err := NewKubernetes(broker, "default", false)
 	if err != nil {
 		t.Skipf("Skipping integration test - could not connect to Kubernetes: %v", err)
 	}

--- a/server/services/kubernetes_test.go
+++ b/server/services/kubernetes_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -50,9 +51,18 @@ func mockKubernetes() *Kubernetes {
 	// Create fake clientset
 	fakeClientSet := k8sfake.NewClientset()
 
+	// Build an informer factory wrapping the fake client. The factory is not
+	// Started here; tests that exercise the cache-read path seed the indexer
+	// directly via factory.ForResource(gvr).Informer().GetIndexer().Add(obj).
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fakeDynamicClient, 0, "", nil)
+	for gvr := range gvrToListKind {
+		_ = factory.ForResource(gvr).Informer()
+	}
+
 	return &Kubernetes{
 		dynamicClient:     fakeDynamicClient,
 		clientSet:         fakeClientSet,
+		factory:           factory,
 		ClusterHost:       "https://test-cluster",
 		Mode:              "test",
 		UseEndpointSlices: false,
@@ -222,15 +232,26 @@ func TestKubernetes_FetchNamespace(t *testing.T) {
 
 	// Create test resources
 	pod := createTestPod("test-pod", "default")
+	otherPod := createTestPod("other-pod", "other-namespace")
 	secret := createTestSecret("test-secret", "default")
 
-	// Add resources to the fake client
+	// Seed the informer caches directly. The cache-read path used by
+	// FetchNamespace does not read through the dynamic client, so we add
+	// objects to the indexers the factory exposes.
 	podGvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	secretGvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 
-	_, _ = k.dynamicClient.Resource(podGvr).Namespace("default").Create(context.TODO(), pod, metaV1.CreateOptions{})
-	_, _ = k.dynamicClient.Resource(secretGvr).Namespace("default").
-		Create(context.TODO(), secret, metaV1.CreateOptions{})
+	if err := k.factory.ForResource(podGvr).Informer().GetIndexer().Add(pod); err != nil {
+		t.Fatalf("failed to seed pod: %v", err)
+	}
+
+	if err := k.factory.ForResource(podGvr).Informer().GetIndexer().Add(otherPod); err != nil {
+		t.Fatalf("failed to seed other-namespace pod: %v", err)
+	}
+
+	if err := k.factory.ForResource(secretGvr).Informer().GetIndexer().Add(secret); err != nil {
+		t.Fatalf("failed to seed secret: %v", err)
+	}
 
 	// Test FetchNamespace
 	data, err := k.FetchNamespace("default")
@@ -238,16 +259,35 @@ func TestKubernetes_FetchNamespace(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	// Check that data contains expected resource types
-	expectedTypes := []string{"pods", "services", "deployments", "secrets", "configmaps"}
+	// Check that data contains expected resource types (response shape)
+	expectedTypes := []string{
+		"pods", "services", "deployments", "replicasets", "statefulsets", "daemonsets",
+		"jobs", "cronjobs", "ingresses", "configmaps", "secrets",
+		"persistentvolumeclaims", "events", "horizontalpodautoscalers",
+	}
 	for _, resourceType := range expectedTypes {
 		if _, exists := data[resourceType]; !exists {
 			t.Errorf("Expected resource type %s to be present in data", resourceType)
 		}
 	}
 
+	// UseEndpointSlices=false in the mock, so endpoints key should be present
+	if _, exists := data["endpoints"]; !exists {
+		t.Error("Expected 'endpoints' key in response (UseEndpointSlices=false)")
+	}
+
+	// Namespace filter: the pod we seeded into "default" must come through,
+	// the pod in "other-namespace" must not.
+	if len(data["pods"]) != 1 {
+		t.Errorf("Expected 1 pod in default namespace, got %d", len(data["pods"]))
+	} else if data["pods"][0].GetName() != "test-pod" {
+		t.Errorf("Expected pod 'test-pod' in default namespace, got %s", data["pods"][0].GetName())
+	}
+
 	// Check that secrets are redacted
-	if secrets, ok := data["secrets"]; ok && len(secrets) > 0 {
+	if secrets, ok := data["secrets"]; !ok || len(secrets) == 0 {
+		t.Error("Expected at least one secret in default namespace, found none")
+	} else {
 		secretData, exists := secrets[0].Object["data"].(map[string]interface{})
 		if !exists {
 			t.Error("Expected secret to have data field")


### PR DESCRIPTION
… handling)

Cumulative patches k8sview's bundled sidecar needs, on top of upstream main:
  - FetchNamespace reads from the informer cache instead of per-request List calls (server/services/kubernetes.go + tests)
  - add a daemonsets informer; LIST_NAMESPACES_ONLY env serves the namespace list with no informers so the server binds on RBAC-restricted clusters
  - /api/namespaces always returns the full list and returns canListNamespaces=false (HTTP 200, not 500) when namespaces.list is forbidden, so the client can fall back to typing a namespace